### PR TITLE
WIP PR to add docs to the snap

### DIFF
--- a/snap/gui/x16emu.programmer-docs.desktop
+++ b/snap/gui/x16emu.programmer-docs.desktop
@@ -1,8 +1,7 @@
 [Desktop Entry]
-Name=Commander X16
-GenericName=Emulator
-Comment=Emulator for the Commander X16 8-bit computer
-Exec=x16emu
+Name=X16 Documentation
+Comment=Documentation Commander X16 8-bit computer
+Exec=x16emu.programmer-docs
 Icon=${SNAP}/meta/gui/x16emu.png
 Type=Application
 Categories=Game;Emulator;

--- a/snap/gui/x16emu.vera-docs.desktop
+++ b/snap/gui/x16emu.vera-docs.desktop
@@ -1,9 +1,9 @@
 [Desktop Entry]
-Name=Commander X16
-GenericName=Emulator
-Comment=Emulator for the Commander X16 8-bit computer
-Exec=x16emu
+Name=X16 VERA Documentation
+Comment=VERA Documentation Commander X16 8-bit computer
+Exec=x16emu.vera-docs
 Icon=${SNAP}/meta/gui/x16emu.png
 Type=Application
 Categories=Game;Emulator;
 Keywords=Game;Emulator;Arcade;
+

--- a/snap/local/docs
+++ b/snap/local/docs
@@ -1,0 +1,2 @@
+#! /bin/sh
+xdg-open file:///"$1"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,46 @@ grade: stable
 confinement: strict
 
 parts:
+  pandoc: # The version of pandoc in Ubuntu 18.04 is too old to build the x16-docs, so we update it
+    source: https://github.com/jgm/pandoc.git
+    source-tag: "2.7.3"
+    plugin: make
+    build-packages: 
+      - ghc
+      - haskell-stack 
+    override-pull: |
+      set -x
+      stack update
+      stack upgrade
+      snapcraftctl pull
+    override-build: |
+      PATH=$HOME/.local/bin:$PATH
+      which stack
+      ls -l
+      cat stack.yaml
+      sed -i 's|"$locals"|locals|g' stack.yaml
+      stack setup
+      stack install
+  docs-launcher:
+    plugin: dump
+    source: snap/local
+  x16-docs: # Generate PDFs of the markdown docs
+    after: [pandoc]
+    source: https://github.com/commanderx16/x16-docs.git
+    plugin: nil
+    override-pull: |
+      snapcraftctl pull
+      # wget https://raw.githubusercontent.com/commanderx16/x16-emulator/master/github-pandoc.css
+      # cp github-pandoc.css $SNAPCRAFT_PART_INSTALL
+      # pandoc --from markdown_github --to html -c github-pandoc.css --standalone --metadata pagetitle="Commander X16 Programmer's Reference Guide" Commander\ X16\ Programmer\'s\ Reference\ Guide.md --output $SNAPCRAFT_PART_INSTALL/Programmer\'s\ Reference\ Guide.html
+      pandoc --from markdown_github -t latex -c github-pandoc.css --standalone --metadata pagetitle="Commander X16 Programmer's Reference Guide" Commander\ X16\ Programmer\'s\ Reference\ Guide.md --output $SNAPCRAFT_PART_INSTALL/Programmer\'s\ Reference\ Guide.pdf
+      # pandoc --from markdown_github --to html -c github-pandoc.css --standalone --metadata pagetitle="VERA Programmer's Reference.md" VERA\ Programmer\'s\ Reference.md --output $SNAPCRAFT_PART_INSTALL/VERA\ Programmer\'s\ Reference.html
+      pandoc --from markdown_github -t latex -c github-pandoc.css --standalone --metadata pagetitle="VERA Programmer's Reference.md" VERA\ Programmer\'s\ Reference.md --output $SNAPCRAFT_PART_INSTALL/VERA\ Programmer\'s\ Reference.pdf
+    build-packages:
+      # - wget
+      - texlive-latex-base
+      - texlive-latex-extra 
+      - texlive-fonts-recommended
   cc65:
     source: https://github.com/cc65/cc65.git
     source-tag: "V2.18"
@@ -107,3 +147,11 @@ apps:
       - home
       - removable-media
       - wayland
+  programmer-docs:
+    command: docs $SNAP/Programmer\'s\ Reference\ Guide.pdf
+    plugs:
+      - desktop
+  vera-docs:
+    command: docs $SNAP/VERA\ Programmer\'s\ Reference.pdf
+    plugs:
+      - desktop


### PR DESCRIPTION
This adds pandoc to build the pdf of the docs from https://github.com/commanderx16/x16-docs and bundle them into the snap. It adds two launcher icons for the pdfs, to make them easy to find.

I expect this will fail to build in launchpad due to the stack command not being able to get through the proxy. I'll file a bug about that against the launchpad builders.