### PR TITLE
Build the ROM with the release version string

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,7 +64,7 @@ parts:
         git checkout "${last_committed_tag}"
       fi
     override-build: |
-      make
+      PRERELEASE_VERSION=$(echo ${last_committed_tag} | grep -oP '[0-9]+$') make
       install build/x16/rom.bin $SNAPCRAFT_PART_INSTALL/
   x16-emulator:
     after: [x16-roms,alsa-mixin]


### PR DESCRIPTION
Untested, but this should work as it's similar to how I added it to our CI.  This change builds the ROM so that the version string shows on the BASIC splash screen.

![image](https://user-images.githubusercontent.com/395186/224398023-13726642-d9dc-46a9-ad13-015038b502cf.png)
